### PR TITLE
Add common data API endpoint

### DIFF
--- a/example.py
+++ b/example.py
@@ -18,3 +18,10 @@ mcd_pe = minecraft_data("1.0", "pe")
 
 print(mcd_pe.version)
 print(mcd_pe.find_item_or_block('stone'))
+
+# Query common data. E.g. to map the protocol version to a minecraft version
+protocol_version = 754 # example protocol version
+for version in minecraft_data.common().protocolVersions:
+    if version["version"] == protocol_version:
+        print(version["minecraftVersion"]) # 1.16.5
+        break

--- a/minecraft_data/__init__.py
+++ b/minecraft_data/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from minecraft_data.tools import convert
+from minecraft_data.tools import convert, commondata
 
 
 class mod(sys.modules[__name__].__class__):
@@ -10,6 +10,12 @@ class mod(sys.modules[__name__].__class__):
             os.path.dirname(__file__), "data/data/"
         )
         return type(version, (object,), convert(_dir, version, edition))
+
+    def common(self, edition = 'pc'):
+        _dir = os.path.join(
+            os.path.dirname(__file__), "data/data/"
+        )
+        return type('common', (object,), commondata(_dir, edition))
 
 
 sys.modules[__name__].__class__ = mod

--- a/minecraft_data/tools.py
+++ b/minecraft_data/tools.py
@@ -41,6 +41,17 @@ def convert(_dir, version, edition ='pc'):
     return ret
 
 
+def commondata(_dir, edition = 'pc'):
+    ret = {}
+    common_path = os.path.join(_dir, edition, 'common')
+    for common_file in os.listdir(common_path):
+        key = common_file.split('.', 1)[0]
+        with open(os.path.join(common_path, common_file)) as f:
+            data = json.load(f)
+            ret.update({key: data})
+    return ret
+
+
 def _grabdata(_dir, datapaths):
     data = {}
     for category, folder in datapaths.items():


### PR DESCRIPTION
With this change it is now possible to access the data inside the "commons" folder. By default it accesses the PC version but it fully supports PE too. It supports all files inside the common folder dynamically (With [2.84.0](https://github.com/PrismarineJS/minecraft-data/tree/2.84.0/data/pc/common) comes a new file). I tried to closely follow the existing API but let me know if I should change something :)

Thanks for the project!

This fixes #20